### PR TITLE
Remove "getRootPageFromUrl" deleted hook from module

### DIFF
--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -54,7 +54,6 @@ $GLOBALS['FE_MOD']['i18nl10n']['i18nl10nLanguageSelection'] = 'Verstaerker\I18nl
 $GLOBALS['TL_HOOKS']['initializeSystem'][]    = array('Verstaerker\I18nl10nBundle\Hook\InitializeSystemHook', 'initializeSystem');
 $GLOBALS['TL_HOOKS']['generateFrontendUrl'][] = array('Verstaerker\I18nl10nBundle\Hook\GenerateFrontendUrlHook', 'generateFrontendUrl');
 $GLOBALS['TL_HOOKS']['getPageIdFromUrl'][]    = array('Verstaerker\I18nl10nBundle\Hook\GetPageIdFromUrlHook', 'getPageIdFromUrl');
-$GLOBALS['TL_HOOKS']['getRootPageFromUrl'][]  = array('Verstaerker\I18nl10nBundle\Hook\GetRootPageFromUrlHook', 'getRootPageFromUrl');
 $GLOBALS['TL_HOOKS']['generateBreadcrumb'][]  = array('Verstaerker\I18nl10nBundle\Hook\GenerateBreadcrumbHook', 'generateBreadcrumb');
 $GLOBALS['TL_HOOKS']['executePostActions'][]  = array('Verstaerker\I18nl10nBundle\Hook\ExecutePostActionsHook', 'executePostActions');
 $GLOBALS['TL_HOOKS']['isVisibleElement'][]    = array('Verstaerker\I18nl10nBundle\Hook\IsVisibleElementHook', 'isVisibleElement');


### PR DESCRIPTION
Hook class deleted in a previous commit but not in config